### PR TITLE
Recipe postでけた🥳

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -36,7 +36,7 @@ class RecipeSerializer(serializers.ModelSerializer):
         model = Recipe
 
         extra_kwargs = {'user': {'read_only': True}}
-        fields = ('title', 'cost', 'amount', 'minutes', 'image', 'user', 'liked',
+        fields = ('id', 'title', 'cost', 'amount', 'minutes', 'image', 'user', 'liked',
                   'created_at', 'updated_at', 'material', 'process')
 
 

--- a/frontend/src/components/pages/Post.jsx
+++ b/frontend/src/components/pages/Post.jsx
@@ -3,6 +3,8 @@ import { TextField, Box, Button, Stack } from "@mui/material";
 import { TextFieldMaterial } from "../atoms/TextFieldMaterial";
 import { TextFieldProcess } from "../atoms/TextFieldProcess";
 import { useRecipe } from "../../hooks/useRecipe";
+import { useMaterial } from "../../hooks/useMaterial";
+import { useProcess } from "../../hooks/useProcess";
 
 export const Post = memo(() => {
   console.log("レンダリング");
@@ -21,20 +23,30 @@ export const Post = memo(() => {
   const [materials, setMaterials] = useState([]);
   const [processes, setProcesses] = useState([]);
 
-  const { createRecipe } = useRecipe();
+  const { createRecipe, newRecipeState } = useRecipe();
+  const { createMaterial } = useMaterial();
+  const { createProcess } = useProcess();
 
   // recipe form のstate関連
   const handleChange = (event) => {
     setRecipeForm({ ...recipeForm, [event.target.name]: event.target.value });
   };
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     recipeForm.cost = Number(recipeForm.cost);
     recipeForm.minutes = Number(recipeForm.minutes);
     recipeForm.image = image;
-    createRecipe(recipeForm);
+    const res = await createRecipe(recipeForm);
+    const id = await newRecipeState.id;
     console.log(materials);
+    materials.map((material) => {
+      return createMaterial(material, id);
+    });
     console.log(processes);
+    processes.map((process) => {
+      return createProcess(process, id);
+    });
+    return res;
   };
 
   return (

--- a/frontend/src/components/pages/Post.jsx
+++ b/frontend/src/components/pages/Post.jsx
@@ -9,9 +9,15 @@ export const Post = memo(() => {
   const [recipeForm, setRecipeForm] = useState({
     title: "",
     cost: "",
+    amount: 1,
     minutes: "",
     image: null,
+    liked: [],
+    material: [],
+    process: [],
   });
+  const [image, setImage] = useState(null);
+
   const [materials, setMaterials] = useState([]);
   const [processes, setProcesses] = useState([]);
 
@@ -23,7 +29,9 @@ export const Post = memo(() => {
   };
 
   const onSubmit = () => {
-    console.log(recipeForm);
+    recipeForm.cost = Number(recipeForm.cost);
+    recipeForm.minutes = Number(recipeForm.minutes);
+    recipeForm.image = image;
     createRecipe(recipeForm);
     console.log(materials);
     console.log(processes);
@@ -35,7 +43,11 @@ export const Post = memo(() => {
         <p>レシピ投稿</p>
         <Box>
           <Stack spacing={2}>
-            <input type="file" name="image" onChange={handleChange} />
+            <input
+              type="file"
+              name="image"
+              onChange={(e) => setImage(e.target.files[0])}
+            />
             <TextField
               label="title"
               name="title"

--- a/frontend/src/hooks/useMaterial.js
+++ b/frontend/src/hooks/useMaterial.js
@@ -1,0 +1,31 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useCallback } from "react";
+import axios from "axios";
+
+export const useMaterial = () => {
+  const createMaterial = useCallback(async (data, id) => {
+    console.log(id);
+    const res = await axios
+      .post(
+        "http://127.0.0.1:8000/api/material/",
+        { name: data.name, amount: data.amount, recipe: id },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `JWT ${localStorage.localJWT}`,
+          },
+        }
+      )
+      .then((res) => {
+        console.log(res.data);
+      })
+      .catch(() => {
+        alert("失敗");
+      });
+    return res;
+  }, []);
+
+  return {
+    createMaterial,
+  };
+};

--- a/frontend/src/hooks/useProcess.js
+++ b/frontend/src/hooks/useProcess.js
@@ -1,0 +1,31 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useCallback } from "react";
+import axios from "axios";
+
+export const useProcess = () => {
+  const createProcess = useCallback(async (data, id) => {
+    console.log(id);
+    const res = await axios
+      .post(
+        "http://127.0.0.1:8000/api/process/",
+        { order: data.order, how_to: data.how_to, recipe: id },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `JWT ${localStorage.localJWT}`,
+          },
+        }
+      )
+      .then((res) => {
+        console.log(res.data);
+      })
+      .catch(() => {
+        alert("失敗");
+      });
+    return res;
+  }, []);
+
+  return {
+    createProcess,
+  };
+};

--- a/frontend/src/hooks/useRecipe.js
+++ b/frontend/src/hooks/useRecipe.js
@@ -3,12 +3,19 @@ import { useCallback } from "react";
 import axios from "axios";
 
 export const useRecipe = () => {
-  const createRecipe = useCallback((data) => {
-    console.log(data);
-    data.cost = Number(data.cost);
-    data.minutes = Number(data.minutes);
-    axios
-      .post("http://127.0.0.1:8000/api/recipe/", data, {
+  const createRecipe = useCallback(async (data) => {
+    const uploadData = new FormData();
+    uploadData.append("title", data.title);
+    uploadData.append("cost", data.cost);
+    uploadData.append("amount", data.amount);
+    uploadData.append("minutes", data.minutes);
+    // uploadData.append("liked", data.liked);
+    // uploadData.append("material", data.material);
+    // uploadData.append("process", data.process);
+    data.image && uploadData.append("image", data.image, data.image.name);
+
+    const res = await axios
+      .post("http://127.0.0.1:8000/api/recipe/", uploadData, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `JWT ${localStorage.localJWT}`,
@@ -20,6 +27,7 @@ export const useRecipe = () => {
       .catch(() => {
         alert("失敗");
       });
+    return res;
   }, []);
 
   return {

--- a/frontend/src/hooks/useRecipe.js
+++ b/frontend/src/hooks/useRecipe.js
@@ -1,8 +1,10 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import axios from "axios";
 
 export const useRecipe = () => {
+  const [newRecipeState, setNewRecipeState] = useState("");
+
   const createRecipe = useCallback(async (data) => {
     const uploadData = new FormData();
     uploadData.append("title", data.title);
@@ -22,7 +24,8 @@ export const useRecipe = () => {
         },
       })
       .then((res) => {
-        console.log(res.data);
+        const newRecipe = res.data;
+        setNewRecipeState(newRecipe);
       })
       .catch(() => {
         alert("失敗");
@@ -32,5 +35,6 @@ export const useRecipe = () => {
 
   return {
     createRecipe,
+    newRecipeState,
   };
 };


### PR DESCRIPTION
## やったこと
- あんまり良くないやり方かもだけど、レシピ・材料・手順のpostをできるようにした。
- 元のUIの行を追加するって感じの実装が結構シビアだったから、テキストフィールドは一つで追加するを押したら表示されるようにした。元のやつのUIの実装も時間があまったら試してほしいけどぼくはこれが限界でした。

## 報告的ななにか
- いったんバルククリエイトじゃなくてもできたからバルククリエイトはまだ試してない。処理がはやくていい感じらしいけどちょい時間的にも後回しにしたさある。
- 大まかなデザインとこまかいデザインはまだできてまへん。
- できないかもってヒヤヒヤしてたストレスから開放された。
- async await 使い方あってるかわからん。