### PR TITLE
スワイプでレシピ一覧の表示

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.4.1",
@@ -24,6 +23,7 @@
         "react-icons": "^4.3.0",
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
+        "react-tinder-card": "^1.4.3",
         "styled-components": "^5.3.1",
         "web-vitals": "^1.1.2"
       }
@@ -13840,6 +13840,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-sleep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-sleep/-/p-sleep-1.1.0.tgz",
+      "integrity": "sha512-bwP3GKZirBUYMtiUuBrheLUQdRXVeE/pmHOaLpNJzNfAD4b5AjDn6l823brXcQFade4G/g7GMNQ3KV86E8EaEw=="
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -16136,6 +16141,24 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/react-tinder-card": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/react-tinder-card/-/react-tinder-card-1.4.3.tgz",
+      "integrity": "sha512-SPKA6zh2pbxl16vfhBk1Wa5jTJKUi10C7afs0WrKIdg6One+DPNHeTTlZSd9NMxCmZ8JdV8RWDe3mDRIT7rpyw==",
+      "dependencies": {
+        "p-sleep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0",
+        "react-dom": "^16.0.0",
+        "react-spring": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-spring": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-transition-group": {
@@ -32437,6 +32460,11 @@
         "retry": "^0.12.0"
       }
     },
+    "p-sleep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-sleep/-/p-sleep-1.1.0.tgz",
+      "integrity": "sha512-bwP3GKZirBUYMtiUuBrheLUQdRXVeE/pmHOaLpNJzNfAD4b5AjDn6l823brXcQFade4G/g7GMNQ3KV86E8EaEw=="
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -34351,6 +34379,14 @@
             }
           }
         }
+      }
+    },
+    "react-tinder-card": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/react-tinder-card/-/react-tinder-card-1.4.3.tgz",
+      "integrity": "sha512-SPKA6zh2pbxl16vfhBk1Wa5jTJKUi10C7afs0WrKIdg6One+DPNHeTTlZSd9NMxCmZ8JdV8RWDe3mDRIT7rpyw==",
+      "requires": {
+        "p-sleep": "^1.1.0"
       }
     },
     "react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react-icons": "^4.3.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-tinder-card": "^1.4.3",
     "styled-components": "^5.3.1",
     "web-vitals": "^1.1.2"
   },

--- a/frontend/src/components/RecipeDeital/Material.jsx
+++ b/frontend/src/components/RecipeDeital/Material.jsx
@@ -8,7 +8,13 @@ export const Material = memo((props) => {
   return (
     <>
       <Box width="100%" marginTop="5px">
-        <Typography m={2} fontWeight="bold" variant="h6">
+        <Typography
+          m={2}
+          fontWeight="bold"
+          variant="h6"
+          borderBottom={4}
+          borderColor="orange"
+        >
           材料(1人前)
         </Typography>
         {materials &&

--- a/frontend/src/components/RecipeDeital/ProcessHome.jsx
+++ b/frontend/src/components/RecipeDeital/ProcessHome.jsx
@@ -1,0 +1,56 @@
+import { memo } from "react";
+
+import { Box, Typography } from "@mui/material";
+
+export const ProcesseHome = memo((props) => {
+  const { processes } = props;
+
+  const compare = (a, b) => {
+    const orderA = a.order;
+    const orderB = b.order;
+
+    let comparison = 0;
+    if (orderA > orderB) {
+      comparison = 1;
+    } else if (orderA < orderB) {
+      comparison = -1;
+    }
+    return comparison;
+  };
+
+  return (
+    <>
+      <Box width="100%" marginTop="5px">
+        <Typography
+          m={2}
+          fontWeight="bold"
+          variant="h6"
+          borderBottom={4}
+          borderColor="orange"
+        >
+          手順
+        </Typography>
+        <Box display="flex" justifyContent="center" flexDirection="column">
+          {processes &&
+            processes.sort(compare).map((process, index) => {
+              return (
+                <Box key={index}>
+                  <Typography
+                    width="80%"
+                    marginX="auto"
+                    marginY="12px"
+                    variant="body1"
+                    fontWeight="medium"
+                    borderBottom={1}
+                    borderColor="grey.500"
+                  >
+                    {process.order}.{process.how_to}
+                  </Typography>
+                </Box>
+              );
+            })}
+        </Box>
+      </Box>
+    </>
+  );
+});

--- a/frontend/src/components/RecipeDeital/Processes.jsx
+++ b/frontend/src/components/RecipeDeital/Processes.jsx
@@ -8,7 +8,13 @@ export const Processes = memo((props) => {
   return (
     <>
       <Box width="100%" marginTop="5px">
-        <Typography m={2} fontWeight="bold" variant="h6">
+        <Typography
+          m={2}
+          fontWeight="bold"
+          variant="h6"
+          borderBottom={4}
+          borderColor="orange"
+        >
           手順
         </Typography>
         <Box display="flex" justifyContent="center" flexDirection="column">

--- a/frontend/src/components/atoms/PrimaryBtn.jsx
+++ b/frontend/src/components/atoms/PrimaryBtn.jsx
@@ -19,7 +19,7 @@ export const PrimaryBtn = memo((props) => {
 const SPrimaryBtn = styled.div`
   display: flex;
   justify-content: center;
-  width: 300px;
+  width: 200px;
   height: 20px;
   margin: 0 auto;
   padding: 10px;

--- a/frontend/src/components/atoms/TitleDiv.jsx
+++ b/frontend/src/components/atoms/TitleDiv.jsx
@@ -24,9 +24,9 @@ export const TitleDiv = memo((props) => {
 const STitleDiv = styled.div`
   display: flex;
   justify-content: center;
-  width: 350px;
+  width: 360px;
   height: 40px;
-  margin-top: 10px;
+  margin-top: 15px;
   margin-left: auto;
   margin-right: auto;
   background-color: #ff9800;

--- a/frontend/src/components/loginConponents/LoginModalForm.jsx
+++ b/frontend/src/components/loginConponents/LoginModalForm.jsx
@@ -1,0 +1,109 @@
+import { memo, useState } from "react";
+import { Box, Typography } from "@mui/material";
+import styled from "styled-components";
+
+import { useAuth } from "../../hooks/useAuth";
+import { LoginBtn } from "./LoginBtn";
+
+export const LoginModalForm = memo(() => {
+  const [mail, setMail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isLogin, setIsLogin] = useState(true);
+
+  const { login, register } = useAuth();
+
+  const onChangeMail = (event) => setMail(event.target.value);
+  const onChangePassword = (event) => setPassword(event.target.value);
+  const onChangeConfirmPassword = (event) =>
+    setConfirmPassword(event.target.value);
+
+  const onClickLogin = () => {
+    return isLogin
+      ? login({ email: mail, password: password })
+      : register({
+          email: mail,
+          password: password,
+          password_confirmation: confirmPassword,
+        });
+  };
+
+  const onClickChangeLoginView = () => setIsLogin(!isLogin);
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      flexDirection="column"
+      width="90%"
+      marginX="auto"
+    >
+      <Typography variant="h6" fontWeight="bold" color="text.primary">
+        {isLogin ? "ログイン" : "新規登録"}
+      </Typography>
+      <Box width="90%">
+        <Box>
+          <AuthLabel htmlFor="email">メールアドレス</AuthLabel>
+          <AuthInputField
+            id="email"
+            placeholder="test@gmail.com"
+            type="text"
+            onChange={onChangeMail}
+            autoComplete="off"
+            value={mail}
+          />
+        </Box>
+        <Box marginTop="10px">
+          <AuthLabel htmlFor="password">パスワード</AuthLabel>
+          <AuthInputField
+            id="password"
+            placeholder="password"
+            type="password"
+            autoComplete="off"
+            onChange={onChangePassword}
+            value={password}
+          />
+        </Box>
+        {isLogin ? null : (
+          <Box marginTop="10px">
+            <AuthLabel htmlFor="confirm_password">パスワード（確認)</AuthLabel>
+            <AuthInputField
+              id="confirm_password"
+              placeholder="password"
+              type="password"
+              autoComplete="off"
+              onChange={onChangeConfirmPassword}
+              value={confirmPassword}
+            />
+          </Box>
+        )}
+      </Box>
+      <Box sx={{ width: "100%" }}>
+        <LoginBtn onClick={onClickLogin}>
+          {isLogin ? "ログイン" : "新規登録"}
+        </LoginBtn>
+      </Box>
+      <Typography
+        color="orange"
+        marginTop="10px"
+        onClick={onClickChangeLoginView}
+      >
+        {isLogin ? "アカウントを作成しますか？" : "ログイン画面へ"}
+      </Typography>
+    </Box>
+  );
+});
+
+const AuthLabel = styled.label`
+  color: #222222;
+`;
+
+const AuthInputField = styled.input`
+  width: 100%;
+  background-color: #e6e6e6;
+  border-radius: 5px;
+  border: none;
+  height: 30px;
+  padding: 5px;
+  margin-top: 10px;
+`;

--- a/frontend/src/components/modal/LoginModal.jsx
+++ b/frontend/src/components/modal/LoginModal.jsx
@@ -1,0 +1,43 @@
+import { memo, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Modal from "@mui/material/Modal";
+import { LoginModalForm } from "../loginConponents/LoginModalForm";
+
+export const LoginModal = memo(() => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const style = {
+    position: "absolute",
+    top: "30%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: 400,
+    bgcolor: "background.paper",
+    border: "2px solid #000",
+    boxShadow: 24,
+    p: 4,
+  };
+
+  return (
+    <>
+      <div>
+        <Button onClick={handleOpen}>Open modal</Button>
+        <Modal
+          open={open}
+          onClose={handleClose}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+        >
+          <Box sx={style}>
+            <Box id="modal-modal-description" sx={{ mt: 2 }}>
+              <LoginModalForm />
+            </Box>
+          </Box>
+        </Modal>
+      </div>
+    </>
+  );
+});

--- a/frontend/src/components/pages/MyPage.jsx
+++ b/frontend/src/components/pages/MyPage.jsx
@@ -21,8 +21,11 @@ export const MyPage = memo(() => {
   const history = useHistory();
 
   useEffect(() => {
-    getMyRecipes();
-    getMyLikedRecipes();
+    const myPageRecipes = async () => {
+      await getMyRecipes();
+      await getMyLikedRecipes();
+    };
+    myPageRecipes();
   }, []);
 
   return (
@@ -39,9 +42,8 @@ export const MyPage = memo(() => {
             justifyContent="center"
             alignItems="center"
           >
-            <TitleDiv>投稿したレシピ</TitleDiv>
-
             <Box width="370px">
+              <TitleDiv>投稿したレシピ</TitleDiv>
               {myRecipes.map((myRecipe) => {
                 return (
                   <SListBox
@@ -53,7 +55,7 @@ export const MyPage = memo(() => {
                       })
                     }
                   >
-                    <Box boxShadow={3} borderRadius={3} height="100px">
+                    <Box height="100px">
                       <SImg src={myRecipe && myRecipe.image} alt="料理" />
                     </Box>
 
@@ -83,9 +85,8 @@ export const MyPage = memo(() => {
             justifyContent="center"
             alignItems="center"
           >
-            <TitleDiv>お気に入りのレシピ</TitleDiv>
-
             <Box width="370px">
+              <TitleDiv>お気に入りのレシピ</TitleDiv>
               {myLikedRecipes.map((myLikedRecipe) => {
                 return (
                   <SListBox
@@ -97,7 +98,7 @@ export const MyPage = memo(() => {
                       })
                     }
                   >
-                    <Box boxShadow={3} borderRadius={3} height="100px">
+                    <Box height="100px">
                       <SImg
                         src={myLikedRecipe && myLikedRecipe.image}
                         alt="料理"
@@ -142,6 +143,7 @@ const SListBox = styled.div`
   cursor: pointer;
   display: flex;
   margin: 10px;
+  box-shadow: 5px 10px 15px -5px rgba(0, 0, 0, 0.2), 0 0 2px rgba(0, 0, 0, 0.15);
 `;
 
 const SImg = styled.img`

--- a/frontend/src/components/pages/MyPage.jsx
+++ b/frontend/src/components/pages/MyPage.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { memo, useEffect } from "react";
 import { useHistory } from "react-router-dom";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, CircularProgress } from "@mui/material";
 
 import styled from "styled-components";
 
@@ -10,8 +10,13 @@ import { TitleDiv } from "../atoms/TitleDiv";
 import { RecipeInfo } from "../MyPage/RecipeInfo";
 
 export const MyPage = memo(() => {
-  const { getMyRecipes, myRecipes, getMyLikedRecipes, myLikedRecipes } =
-    useRecipe();
+  const {
+    getMyRecipes,
+    myRecipes,
+    getMyLikedRecipes,
+    myLikedRecipes,
+    loading,
+  } = useRecipe();
 
   const history = useHistory();
 
@@ -21,81 +26,105 @@ export const MyPage = memo(() => {
   }, []);
 
   return (
-    <Box width="90%" mx="auto">
-      <Box
-        display="flex"
-        flexDirection="column"
-        justifyContent="center"
-        alignItems="center"
-      >
-        <TitleDiv>投稿したレシピ</TitleDiv>
-
-        <Box width="370px">
-          {myRecipes.map((myRecipe) => {
-            return (
-              <SListBox
-                key={myRecipe.id}
-                onClick={() =>
-                  history.push({
-                    pathname: "/detail",
-                    state: { id: myRecipe.id },
-                  })
-                }
-              >
-                <SImg src={myRecipe && myRecipe.image} alt="料理" />
-                <SRecipeBox>
-                  <Typography variant="body1" fontWeight="bold" marginTop="5px">
-                    {myRecipe.title}
-                  </Typography>
-                  <RecipeInfo
-                    likes_count={myRecipe.likes_count}
-                    minutes={myRecipe.minutes}
-                    cost={myRecipe.cost}
-                  />
-                </SRecipeBox>
-              </SListBox>
-            );
-          })}
+    <>
+      {loading ? (
+        <Box display="flex" justifyContent="center">
+          <CircularProgress />
         </Box>
-      </Box>
+      ) : (
+        <Box width="90%" mx="auto">
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <TitleDiv>投稿したレシピ</TitleDiv>
 
-      <Box
-        display="flex"
-        flexDirection="column"
-        justifyContent="center"
-        alignItems="center"
-      >
-        <TitleDiv>お気に入りのレシピ</TitleDiv>
+            <Box width="370px">
+              {myRecipes.map((myRecipe) => {
+                return (
+                  <SListBox
+                    key={myRecipe.id}
+                    onClick={() =>
+                      history.push({
+                        pathname: "/detail",
+                        state: { id: myRecipe.id },
+                      })
+                    }
+                  >
+                    <Box boxShadow={3} borderRadius={3} height="100px">
+                      <SImg src={myRecipe && myRecipe.image} alt="料理" />
+                    </Box>
 
-        <Box width="370px">
-          {myLikedRecipes.map((myLikedRecipe) => {
-            return (
-              <SListBox
-                key={myLikedRecipe.id}
-                onClick={() =>
-                  history.push({
-                    pathname: "/detail",
-                    state: { id: myLikedRecipe.id },
-                  })
-                }
-              >
-                <SImg src={myLikedRecipe && myLikedRecipe.image} alt="料理" />
-                <SRecipeBox>
-                  <Typography variant="body1" fontWeight="bold" marginTop="5px">
-                    {myLikedRecipe.title}
-                  </Typography>
-                  <RecipeInfo
-                    likes_count={myLikedRecipe.likes_count}
-                    minutes={myLikedRecipe.minutes}
-                    cost={myLikedRecipe.cost}
-                  />
-                </SRecipeBox>
-              </SListBox>
-            );
-          })}
+                    <SRecipeBox>
+                      <Typography
+                        variant="body1"
+                        fontWeight="bold"
+                        marginTop="5px"
+                      >
+                        {myRecipe.title}
+                      </Typography>
+                      <RecipeInfo
+                        likes_count={myRecipe.likes_count}
+                        minutes={myRecipe.minutes}
+                        cost={myRecipe.cost}
+                      />
+                    </SRecipeBox>
+                  </SListBox>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <TitleDiv>お気に入りのレシピ</TitleDiv>
+
+            <Box width="370px">
+              {myLikedRecipes.map((myLikedRecipe) => {
+                return (
+                  <SListBox
+                    key={myLikedRecipe.id}
+                    onClick={() =>
+                      history.push({
+                        pathname: "/detail",
+                        state: { id: myLikedRecipe.id },
+                      })
+                    }
+                  >
+                    <Box boxShadow={3} borderRadius={3} height="100px">
+                      <SImg
+                        src={myLikedRecipe && myLikedRecipe.image}
+                        alt="料理"
+                      />
+                    </Box>
+                    <SRecipeBox>
+                      <Typography
+                        variant="body1"
+                        fontWeight="bold"
+                        marginTop="5px"
+                      >
+                        {myLikedRecipe.title}
+                      </Typography>
+                      <RecipeInfo
+                        likes_count={myLikedRecipe.likes_count}
+                        minutes={myLikedRecipe.minutes}
+                        cost={myLikedRecipe.cost}
+                      />
+                    </SRecipeBox>
+                  </SListBox>
+                );
+              })}
+            </Box>
+          </Box>
         </Box>
-      </Box>
-    </Box>
+      )}
+    </>
   );
 });
 
@@ -120,5 +149,4 @@ const SImg = styled.img`
   width: 100px;
   object-fit: cover;
   border-radius: 10px;
-  margin: 2px;
 `;

--- a/frontend/src/components/pages/Post.jsx
+++ b/frontend/src/components/pages/Post.jsx
@@ -64,7 +64,7 @@ export const Post = memo(() => {
 
   return (
     <>
-      <Box my={4} mx="auto" width={370}>
+      <Box my={4} mx="auto" width="375px">
         <TitleDiv>レシピ投稿</TitleDiv>
 
         <Box paddingX={2}>

--- a/frontend/src/components/pages/RecipeDetail.jsx
+++ b/frontend/src/components/pages/RecipeDetail.jsx
@@ -37,16 +37,19 @@ export const RecipeDetail = memo(() => {
         marginBottom: "50px",
       }}
     >
-      <Typography alignSelf="start" m={2} fontWeight="bold" variant="h5">
-        {selectedRecipe && selectedRecipe.title}
-      </Typography>
-      <Box>
+      <SRecipeTitle>
+        <Typography fontWeight="bold" p={1} color="white" variant="h5">
+          {selectedRecipe && selectedRecipe.title}
+        </Typography>
+      </SRecipeTitle>
+
+      <Box boxShadow={3} borderRadius={3} height="400px" width="360px">
         <SImg src={selectedRecipe && selectedRecipe.image} alt="料理" />
       </Box>
 
       <Box
         width="100%"
-        marginTop="5px"
+        marginTop="10px"
         display="flex"
         justifyContent="space-between"
       >
@@ -62,10 +65,17 @@ export const RecipeDetail = memo(() => {
   );
 });
 
+const SRecipeTitle = styled.div`
+  margin: 15px 0;
+  width: 370px;
+  height: 40px;
+  background-color: #ff9800;
+  border-radius: 10px;
+`;
+
 const SImg = styled.img`
-  height: 400px;
-  width: 360px;
+  height: 100%;
+  width: 100%;
   object-fit: cover;
   border-radius: 10px;
-  margin: 2px;
 `;

--- a/frontend/src/components/pages/RecipeDisplay.jsx
+++ b/frontend/src/components/pages/RecipeDisplay.jsx
@@ -1,57 +1,104 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { memo, useState, useEffect } from "react";
+import { memo, useState, useEffect, useCallback } from "react";
 import axios from "axios";
-import Recipe from "./Recipe";
+import TinderCard from "react-tinder-card";
+import styled from "styled-components";
+import { Box } from "@mui/material";
+
+import "../../css/RecipeDisplay.css";
+import { RecipeInfo } from "../MyPage/RecipeInfo";
+import { Material } from "../RecipeDeital/Material";
+import { ProcesseHome } from "../RecipeDeital/ProcessHome";
 
 export const RecipeDisplay = memo(() => {
+  console.log("display");
   const [recipes, setRecipes] = useState([]);
-  const [display, setDisplay] = useState({});
-  const [id, setId] = useState(0);
-  const [logInId, setLogInId] = useState(0);
 
-  const likeRecipe = (recipeId, liked, isDisplayed) => {
-    setId((prev) => prev + 1);
-    // console.log(recipeId);
-    // console.log(liked);
+  // recipe 詳細情報取得用
+  const [nowRecipe, setNowRecipe] = useState(undefined);
+  const [count, setCount] = useState(1);
+  const [isDetail, setIsDetail] = useState(false);
 
-    if (!liked.includes(logInId) && !isDisplayed.includes(logInId)) {
-      liked.push(logInId);
-      isDisplayed.push(logInId);
+  const likeRecipe = useCallback(async (recipe) => {
+    const resMyId = await axios.get("http://127.0.0.1:8000/api/myself", {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `JWT ${localStorage.localJWT}`,
+      },
+    });
+    const myId = await resMyId.data.id;
+
+    if (!recipe.liked.includes(myId) && !recipe.isDisplayed.includes(myId)) {
+      await recipe.liked.push(myId);
+      await recipe.isDisplayed.push(myId);
+
       const likedData = {
-        liked: liked,
-        isDisplayed: isDisplayed,
+        liked: recipe.liked,
+        isDisplayed: recipe.isDisplayed,
       };
-      console.log(likedData);
-      axios.patch(`http://127.0.0.1:8000/api/recipe/${recipeId}/`, likedData, {
+
+      axios.patch(`http://127.0.0.1:8000/api/recipe/${recipe.id}/`, likedData, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `JWT ${localStorage.localJWT}`,
         },
       });
     }
-    // console.log(liked);
-  };
+  }, []);
 
-  const dislikeRecipe = (recipeId, isDisplayed) => {
-    setId((prev) => prev + 1);
-
-    if (!isDisplayed.includes(logInId)) {
-      isDisplayed.push(logInId);
+  const dislikeRecipe = useCallback(async (recipeId, isDisplayed) => {
+    const resMyId = await axios.get("http://127.0.0.1:8000/api/myself", {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `JWT ${localStorage.localJWT}`,
+      },
+    });
+    const myId = await resMyId.data.id;
+    if (!isDisplayed.includes(myId)) {
+      isDisplayed.push(myId);
       const dislikedData = {
         isDisplayed: isDisplayed,
       };
-      axios.patch(`http://127.0.0.1:8000/api/recipe/${recipeId}/`, dislikedData, {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `JWT ${localStorage.localJWT}`,
-        },
-      });
-    };
-  };
+      axios.patch(
+        `http://127.0.0.1:8000/api/recipe/${recipeId}/`,
+        dislikedData,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `JWT ${localStorage.localJWT}`,
+          },
+        }
+      );
+    }
+  }, []);
 
-  useEffect(() => {
-    setDisplay(recipes[id]);
-  }, [id]);
+  // liked と isDisplayedの初期化
+  // error でるけど何回か押してたら初期化される
+  const Reset = async () => {
+    const resRecipes = await axios.get("http://127.0.0.1:8000/api/recipe/", {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `JWT ${localStorage.localJWT}`,
+      },
+    });
+
+    const allRecipes = await resRecipes.data;
+    const likedData = {
+      liked: [],
+      isDisplayed: [],
+    };
+    for (let i = 0; i < allRecipes.length; i++) {
+      const id = allRecipes[i].id;
+      if (allRecipes[i].liked !== [] || allRecipes[i].isDisplayed !== []) {
+        axios.patch(`http://127.0.0.1:8000/api/recipe/${id}/`, likedData, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `JWT ${localStorage.localJWT}`,
+          },
+        });
+      }
+    }
+  };
 
   useEffect(() => {
     const getAllRecipe = async () => {
@@ -63,7 +110,6 @@ export const RecipeDisplay = memo(() => {
       });
 
       const allRecipes = await resRecipes.data;
-
       const resMyId = await axios.get("http://127.0.0.1:8000/api/myself", {
         headers: {
           "Content-Type": "application/json",
@@ -72,39 +118,172 @@ export const RecipeDisplay = memo(() => {
       });
 
       const myId = await resMyId.data.id;
-
       const isNotDisplayedRecipes = await allRecipes.filter((recipe) => {
         return !recipe.isDisplayed.includes(myId);
       });
 
       setRecipes(isNotDisplayedRecipes);
-      setDisplay(isNotDisplayedRecipes[0]);
-      setLogInId(myId);
     };
 
     getAllRecipe();
   }, []);
 
+  // swipe
+  const swiped = useCallback((direction, recipe) => {
+    if (direction === "right") {
+      console.log(direction);
+      likeRecipe(recipe);
+    } else if (direction === "left") {
+      console.log(direction);
+      dislikeRecipe(recipe.id, recipe.isDisplayed);
+    }
+    setCount((pre) => pre + 1);
+    setIsDetail(false);
+  }, []);
+
   return (
     <>
-      {display ? (
-        <Recipe
-          recipeId={display.id}
-          title={display.title}
-          cost={display.cost}
-          amount={display.amount}
-          minutes={display.minutes}
-          image={display.image}
-          material={display.material}
-          process={display.process}
-          userId={display.user}
-          liked={display.liked}
-          isDisplayed={display.isDisplayed}
-          onClickLike={likeRecipe}
-          onClickDislike={dislikeRecipe}
-          key={display.title}
-        />
-      ) : null}
+      <button onClick={() => Reset()}>reset</button>
+
+      <SRootDiv>
+        <SAppDiv>
+          <SCardContainer>
+            {recipes.map((recipe) => {
+              return (
+                <TinderCard
+                  className="swipe"
+                  preventSwipe={["up", "down"]}
+                  onSwipe={(dir) => swiped(dir, recipe)}
+                  key={recipe.id}
+                >
+                  <SCard>
+                    <SCardContent>
+                      <Box
+                        height="300px"
+                        width="300px"
+                        boxShadow={4}
+                        borderRadius={3}
+                        marginTop="10px"
+                      >
+                        <SImg src={recipe.image} alt="image" />
+                      </Box>
+
+                      <h3>{recipe.title}</h3>
+                      <RecipeInfo
+                        likes_count={recipe.likes_count}
+                        minutes={recipe.minutes}
+                        cost={recipe.cost}
+                      />
+                    </SCardContent>
+                  </SCard>
+                </TinderCard>
+              );
+            })}
+          </SCardContainer>
+        </SAppDiv>
+      </SRootDiv>
+      <SDetailDiv>
+        <SBtn
+          onClick={() => {
+            setNowRecipe(recipes[recipes.length - count]);
+            setIsDetail(!isDetail);
+          }}
+        >
+          {isDetail ? "閉じる" : "詳細を見る"}
+        </SBtn>
+        {isDetail ? (
+          <SDetailContents>
+            <Material materials={nowRecipe && nowRecipe.material} />
+            <ProcesseHome processes={nowRecipe && nowRecipe.process} />
+          </SDetailContents>
+        ) : null}
+      </SDetailDiv>
     </>
   );
 });
+
+const SRootDiv = styled.div`
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  width: 100vw;
+  height: 450px;
+  overflow: hidden;
+  > div {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+const SAppDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SImg = styled.img`
+  height: 300px;
+  width: 300px;
+  object-fit: cover;
+  border-radius: 10px;
+`;
+
+const SCardContainer = styled.div`
+  width: 90vw;
+  height: 95vh;
+  display: flex;
+  justify-content: center;
+`;
+
+const SCard = styled.div`
+  background-color: rgb(255, 255, 255);
+  box-shadow: 0px 0px 15px 0px rgba(34, 34, 34, 0.3);
+  min-width: 320px;
+  height: 400px;
+  border-radius: 20px;
+  background-size: cover;
+  background-position: center;
+  padding: 5px;
+`;
+
+const SCardContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const SDetailDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const SBtn = styled.button`
+  border-radius: 10px;
+  border: none;
+  width: 200px;
+  height: 40px;
+  background-color: #ff9800;
+  padding: 10px;
+  color: #ffffff;
+  font-size: large;
+  font-weight: 800;
+  margin: 0 auto;
+  &:hover {
+    opacity: 0.8;
+    cursor: pointer;
+  }
+`;
+
+const SDetailContents = styled.div`
+  width: 320px;
+  margin: 0 auto;
+  min-width: 320px;
+  border-radius: 20px;
+  background-color: white;
+  margin-bottom: 50px;
+`;

--- a/frontend/src/components/pages/Top.jsx
+++ b/frontend/src/components/pages/Top.jsx
@@ -3,6 +3,7 @@ import { useHistory } from "react-router-dom";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import img from "../../img/photo-1490645935967-10de6ba17061.jpeg";
+import { LoginModal } from "../modal/LoginModal";
 
 export const Top = memo(() => {
   const history = useHistory();
@@ -15,12 +16,13 @@ export const Top = memo(() => {
 
   return (
     <>
-      <Box sx={{
-        display: "flex",　
-        justifyContent: "center" , 
-        backgroundImage: `url(${img})` , 
-        backgroundSize:"cover" , 
-        height:"calc(100vh - 64px)"
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          backgroundImage: `url(${img})`,
+          backgroundSize: "cover",
+          height: "calc(100vh - 64px)",
         }}
       >
         <Box
@@ -36,7 +38,7 @@ export const Top = memo(() => {
               display: "flex",
               alignItems: "center",
               flexDirection: "column",
-              margin: "40px 0 136px 0"
+              margin: "40px 0 136px 0",
             }}
           >
             <h1 style={{ color: "white", fontSize: "48px" }}>Reciper</h1>
@@ -51,7 +53,7 @@ export const Top = memo(() => {
               width: "100%",
               display: "flex",
               alignItems: "center",
-              flexDirection: "column"
+              flexDirection: "column",
             }}
           >
             <Button
@@ -61,9 +63,14 @@ export const Top = memo(() => {
             >
               レシピを投稿する
             </Button>
-            <Button variant="contained" sx={{ marginBottom: "8px" , width: "60%" }} onClick={toRecipes} >
+            <Button
+              variant="contained"
+              sx={{ marginBottom: "8px", width: "60%" }}
+              onClick={toRecipes}
+            >
               レシピを見つける
             </Button>
+            <LoginModal />
           </Box>
         </Box>
       </Box>

--- a/frontend/src/css/RecipeDisplay.css
+++ b/frontend/src/css/RecipeDisplay.css
@@ -1,0 +1,30 @@
+.swipe {
+  position: absolute;
+}
+
+.swipe:last-of-type {
+}
+
+@keyframes popup {
+  0% {
+    transform: scale(1, 1);
+  }
+  10% {
+    transform: scale(1.1, 1.1);
+  }
+  30% {
+    transform: scale(0.9, 0.9);
+  }
+  50% {
+    transform: scale(1, 1);
+  }
+  57% {
+    transform: scale(1, 1);
+  }
+  64% {
+    transform: scale(1, 1);
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}

--- a/frontend/src/hooks/useRecipe.js
+++ b/frontend/src/hooks/useRecipe.js
@@ -69,7 +69,7 @@ export const useRecipe = () => {
       })
       .then((res) => setMyLikedRecipes(res.data))
       .finally(() => setLoading(false));
-  });
+  }, []);
 
   const createRecipe = useCallback(async (data) => {
     const uploadData = new FormData();

--- a/frontend/src/hooks/useRecipe.js
+++ b/frontend/src/hooks/useRecipe.js
@@ -6,8 +6,10 @@ export const useRecipe = () => {
   const [myRecipes, setMyRecipes] = useState([]);
   const [selectedRecipe, setSelectedRecipe] = useState(undefined);
   const [myLikedRecipes, setMyLikedRecipes] = useState([]);
+  const [loading, setLoading] = useState(false);
 
   const getMyRecipes = useCallback(async () => {
+    setLoading(true);
     const res = await axios.get("http://127.0.0.1:8000/api/myself/", {
       headers: {
         "Content-Type": "application/json",
@@ -65,7 +67,8 @@ export const useRecipe = () => {
           Authorization: `JWT ${localStorage.localJWT}`,
         },
       })
-      .then((res) => setMyLikedRecipes(res.data));
+      .then((res) => setMyLikedRecipes(res.data))
+      .finally(() => setLoading(false));
   });
 
   const createRecipe = useCallback(async (data) => {
@@ -97,5 +100,6 @@ export const useRecipe = () => {
     myLikedRecipes,
     getSelectedRecipe,
     selectedRecipe,
+    loading,
   };
 };


### PR DESCRIPTION
react-tinder-cardをinstallしたので確認時に```npm install```おねがいします。
RecipeDisplay.jsxが主な変更箇所です。
TinderCard内はスワイプの処理しか出来なさそうなのでTinderCard外にボタンをおいて、recipes配列からデータをとってくるみたいな処理をしています。他の方法わからなかったです！
reset関数は毎回管理画面からlikedとisDisplayedの値を外すのが面倒だったので、リセットボタン押せば（コンソールにエラーって出るけど2、３回押せば結構初期化される）また表示されるようにしました。